### PR TITLE
Updated serialport library so it will work with recent versions of node

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "nomnom": "^1.8.0",
     "q": "^1.1.2",
     "relaxed-json": "^0.2.8",
-    "serialport": "^1.6.3",
+    "serialport": "^2.0.5",
     "sprintf": "^0.1.4"
   },
   "bin": {


### PR DESCRIPTION
The current version of serialport is outdated and will not install on recent versions of node for raspberrypi and mac.  I've tested this version to be working across the board.
